### PR TITLE
Add &enabledrpg

### DIFF
--- a/Commands/settings/enabledrpg.js
+++ b/Commands/settings/enabledrpg.js
@@ -123,6 +123,10 @@ module.exports = class EnableDRPGCommand extends Command {
                     await this.setUserSettings(message);
                     this.done(message);
                 }
+                else if (!guildEnabled) {
+                    await this.setGuildSettings(message);
+                    this.done(message);
+                }
                 else if (!userEnabled) {
                     await this.setUserSettings(message);
                     this.done(message);

--- a/Commands/settings/enabledrpg.js
+++ b/Commands/settings/enabledrpg.js
@@ -1,166 +1,130 @@
 const { MessageEmbed } = require("discord.js");
 const { Command } = require("../../structures/categories/SettingsCategory");
 
-// I'm too dumb to think of how to define these constants in a function
-// Please tell me where these should go honestly
+const descriptions = {
+	healthMonitor: "DiscordRPG Health Monitor",
+	adventureTimer: "DiscordRPG Adventure Timer",
+	sidesTimer: "DiscordRPG Sides Timer"
+};
 const guildParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
 const userParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
 
 module.exports = class EnableDRPGCommand extends Command {
-  constructor(client) {
-    super(client, {
-      name: "enabledrpg",
-      description:
-        "Utility command to enable configuration values for DiscordRPG usage"
-    });
-  }
+	constructor(client) {
+		super(client, {
+			name: "enabledrpg",
+			description:
+				"Utility command to enable configuration values for DiscordRPG usage"
+		});
+	}
 
-  async setGuildSettings(message) {
-    const { prefix } = message.guild;
+	// eslint-disable-next-line class-methods-use-this
+	configuringEmbed(message, type) {
+		const { prefix } = message.guild;
+		const parameters = type ? userParameters : guildParameters;
+		return new MessageEmbed()
+			.setTitle(`Configuring ${type}'s settings`)
+			.setDescription(`**This will enable the following ${
+				type} settings:**\n${
+				parameters.reduce((p, c) => `${p}${`${descriptions[c]} - \`${c}\``}\n`, "")
+			}**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}${type[0]}config\`.`)
+			.setColor("BLUE");
+	}
 
-    const embed = new MessageEmbed()
-      .setTitle("Configuring Guild Settings")
-      .setDescription(
-        "**This will enable the following Guild settings:**\n" +
-          "DRPG Health Monitor - `healthMonitor`" +
-          "\n" +
-          "DRPG Adventure Timer - `adventureTimer`" +
-          "\n" +
-          "DRPG Sides Timer - `sidesTimer`" +
-          "\n" +
-          `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}gconfig\`.`
-      )
-      .setColor("BLUE");
-    const checkMark = "✅";
-    const filter = (r, u) =>
-      r.emoji.name === checkMark && u.id === message.author.id;
+	setUserSettings(message) {
+		return new Promise(async resolve => {
+			const embed = this.configuringEmbed(message, "user");
+			const checkMark = "✅";
+			const filter = (r, u) => r.emoji.name === checkMark
+				&& u.id === message.author.id;
+			const msg = await message.channel.send({ embed });
+			await msg.react(checkMark);
+			msg.awaitReactions(filter, { time: 30000, max: 1, errors: ["time"] }).then(() => {
+				userParameters.forEach(parameter => {
+					message.author.changeSetting(parameter, "on");
+				});
+				resolve();
+			}).catch(() => {
+				msg.reactions.removeAll();
+				msg.edit("The operation has been cancelled.");
+			});
+		});
+	}
 
-    const msg = await message.channel.send({ embed });
-    await msg.react(checkMark);
-    try {
-      await msg.awaitReactions(filter, {
-        time: 30000,
-        max: 1,
-        errors: ["time"]
-      });
-      guildParameters.forEach(parameter => {
-        message.guild.changeSetting(parameter, "on");
-      });
-    } catch (err) {
-      msg.reactions.removeAll();
-      msg.edit(`The operation has been cancelled.`);
-      throw err;
-    }
-  }
+	setGuildSettings(message) {
+		return new Promise(async resolve => {
+			const embed = this.configuringEmbed(message, "guild");
+			const checkMark = "✅";
+			const filter = (r, u) => r.emoji.name === checkMark
+				&& u.id === message.author.id;
+			const msg = await message.channel.send({ embed });
+			await msg.react(checkMark);
+			msg.awaitReactions(filter, { time: 30000, max: 1, errors: ["time"] }).then(() => {
+				guildParameters.forEach(parameter => {
+					message.guild.changeSetting(parameter, "on");
+				});
+				resolve();
+			}).catch(() => {
+				msg.reactions.removeAll();
+				msg.edit("The operation has been cancelled.");
+			});
+		});
+	}
 
-  async setUserSettings(message) {
-    const { prefix } = message.guild;
+	// eslint-disable-next-line class-methods-use-this
+	done(message) {
+		const { prefix } = message.guild;
+		const embed = new MessageEmbed()
+			.setTitle("Done!")
+			.setDescription(
+				`Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health.\nYou can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
+			)
+			.setColor("GREEN");
+		message.channel.send({ embed });
+	}
 
-    const embed = new MessageEmbed()
-      .setTitle("Configuring User Settings")
-      .setDescription(
-        "**This will enable the following User settings:**\n" +
-          "DRPG Health Monitor - `healthMonitor`" +
-          "\n" +
-          "DRPG Adventure Timer - `adventureTimer`" +
-          "\n" +
-          "DRPG Sides Timer - `sidesTimer`" +
-          "\n" +
-          `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}uconfig\`.`
-      )
-      .setColor("BLUE");
+	// eslint-disable-next-line class-methods-use-this
+	noPermissions(message) {
+		const { prefix } = message.guild;
+		const embed = new MessageEmbed()
+			.setTitle("Oops!")
+			.setDescription(
+				`This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
+			)
+			.setColor("RED");
+		message.channel.send({ embed });
+	}
 
-    const checkMark = "✅";
-    const filter = (r, u) =>
-      r.emoji.name === checkMark && u.id === message.author.id;
+	// eslint-disable-next-line class-methods-use-this
+	async run(bot, message) {
+		const isAdmin = message.member
+			.permissionsIn(message.channel)
+			.has("ADMINISTRATOR");
 
-    const msg = await message.channel.send({ embed });
-    await msg.react(checkMark);
-    try {
-      await msg.awaitReactions(filter, {
-        time: 30000,
-        max: 1,
-        errors: ["time"]
-      });
-      userParameters.forEach(parameter => {
-        message.author.changeSetting(parameter, "on");
-      });
-    } catch (err) {
-      msg.reactions.removeAll();
-      msg.edit(`The operation has been cancelled.`);
-      throw err;
-    }
-  }
+		const guildEnabled = guildParameters
+			.every(parameter => message.guild.settings[parameter] === "on");
+		const userEnabled = userParameters
+			.every(parameter => message.author.settings[parameter] === "on");
 
-  done(message) {
-    const { prefix } = message.guild;
-    const embed = new MessageEmbed()
-      .setTitle("Done!")
-      .setDescription(
-        "Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health." +
-          "\n" +
-          `You can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
-      )
-      .setColor("GREEN");
-    message.channel.send({ embed });
-  }
-
-  noPermissions(message) {
-    const { prefix } = message.guild;
-    const embed = new MessageEmbed()
-      .setTitle("Oops!")
-      .setDescription(
-        `This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
-      )
-      .setColor("RED");
-    message.channel.send({ embed });
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async run(bot, message, args) {
-    const isAdmin = message.member
-      .permissionsIn(message.channel)
-      .has("Administrator");
-
-    const guildEnabled = guildParameters.every(parameter => {
-      return message.guild.settings[parameter] === "on";
-    });
-    const userEnabled = userParameters.every(parameter => {
-      return message.author.settings[parameter] === "on";
-    });
-
-    // This is what I could think of for making it stop immediately if one of the functions
-    // time out. A side effect is that errors here aren't caught properly. How does one tell a timer error
-    // from a regular error with the code?
-    // (Please don't approve this PR without thinking over it a little bit.)
-    try {
-      if (isAdmin) {
-        if (!guildEnabled && !userEnabled) {
-          await this.setGuildSettings(message);
-          await this.setUserSettings(message);
-          this.done(message);
-        } else if (!guildEnabled) {
-          await this.setGuildSettings(message);
-          this.done(message);
-        } else if (!userEnabled) {
-          await this.setUserSettings(message);
-          this.done(message);
-        } else {
-          this.done(message);
-        }
-      }
-      if (!isAdmin) {
-        if (!guildEnabled) {
-          this.noPermissions(message);
-        } else if (!userEnabled) {
-          await this.setUserSettings(message);
-          this.done(message);
-        } else {
-          this.done(message);
-        }
-      }
-    } catch (err) {
-      return;
-    }
-  }
+		if (isAdmin && !guildEnabled && !userEnabled) {
+			await this.setGuildSettings(message);
+			await this.setUserSettings(message);
+			this.done(message);
+		} else if (isAdmin && !guildEnabled) {
+			await this.setGuildSettings(message);
+			this.done(message);
+		} else if (isAdmin && !userEnabled) {
+			await this.setUserSettings(message);
+			this.done(message);
+		} else if (isAdmin) {
+			this.done(message);
+		} else if (!isAdmin && !guildEnabled) {
+			this.noPermissions(message);
+		} else if (!isAdmin && !userEnabled) {
+			await this.setUserSettings(message);
+			this.done(message);
+		} else {
+			this.done(message);
+		}
+	}
 };

--- a/Commands/settings/enabledrpg.js
+++ b/Commands/settings/enabledrpg.js
@@ -7,160 +7,154 @@ const guildParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
 const userParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
 
 module.exports = class EnableDRPGCommand extends Command {
-  constructor(client) {
-    super(client, {
-      name: "enabledrpg",
-      description:
+	constructor(client) {
+		super(client, {
+			name: "enabledrpg",
+			description:
         "Utility command to enable configuration values for DiscordRPG usage"
-    });
-  }
+		});
+	}
 
-  async setGuildSettings(message) {
-    const { prefix } = message.guild;
+	async setGuildSettings(message) {
+		const { prefix } = message.guild;
 
-    const embed = new MessageEmbed()
-      .setTitle("Configuring Guild Settings")
-      .setDescription(
-        "**This will enable the following Guild settings:**\n" +
-          "DRPG Health Monitor - `healthMonitor`" +
-          "\n" +
-          "DRPG Adventure Timer - `adventureTimer`" +
-          "\n" +
-          "DRPG Sides Timer - `sidesTimer`" +
-          "\n" +
-          `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}gconfig\`.`
-      )
-      .setColor("BLUE");
-    const checkMark = "✅";
-    const filter = (r, u) =>
-      r.emoji.name === checkMark && u.id === message.author.id;
+		const embed = new MessageEmbed()
+			.setTitle("Configuring Guild Settings")
+			.setDescription(
+				"**This will enable the following Guild settings:**\n"
+          + "DRPG Health Monitor - `healthMonitor`"
+          + "\n"
+          + "DRPG Adventure Timer - `adventureTimer`"
+          + "\n"
+          + "DRPG Sides Timer - `sidesTimer`"
+          + "\n"
+          + `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}gconfig\`.`
+			)
+			.setColor("BLUE");
+		const checkMark = "✅";
+		const filter = (r, u) => r.emoji.name === checkMark && u.id === message.author.id;
 
-    const msg = await message.channel.send({ embed });
-    await msg.react(checkMark);
-    try {
-      await msg.awaitReactions(filter, {
-        time: 30000,
-        max: 1,
-        errors: ["time"]
-      });
-      guildParameters.forEach(parameter => {
-        message.guild.changeSetting(parameter, "on");
-      });
-    } catch (err) {
-      msg.reactions.removeAll();
-      msg.edit(`The operation has been cancelled.`);
-      throw err;
-    }
-  }
+		const msg = await message.channel.send({ embed });
+		await msg.react(checkMark);
+		try {
+			await msg.awaitReactions(filter, {
+				time: 30000,
+				max: 1,
+				errors: ["time"]
+			});
+			guildParameters.forEach(parameter => {
+				message.guild.changeSetting(parameter, "on");
+			});
+		} catch (err) {
+			msg.reactions.removeAll();
+			msg.edit("The operation has been cancelled.");
+			throw err;
+		}
+	}
 
-  async setUserSettings(message) {
-    const { prefix } = message.guild;
+	async setUserSettings(message) {
+		const { prefix } = message.guild;
 
-    const embed = new MessageEmbed()
-      .setTitle("Configuring User Settings")
-      .setDescription(
-        "**This will enable the following User settings:**\n" +
-          "DRPG Health Monitor - `healthMonitor`" +
-          "\n" +
-          "DRPG Adventure Timer - `adventureTimer`" +
-          "\n" +
-          "DRPG Sides Timer - `sidesTimer`" +
-          "\n" +
-          `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}uconfig\`.`
-      )
-      .setColor("BLUE");
+		const embed = new MessageEmbed()
+			.setTitle("Configuring User Settings")
+			.setDescription(
+				"**This will enable the following User settings:**\n"
+          + "DRPG Health Monitor - `healthMonitor`"
+          + "\n"
+          + "DRPG Adventure Timer - `adventureTimer`"
+          + "\n"
+          + "DRPG Sides Timer - `sidesTimer`"
+          + "\n"
+          + `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}uconfig\`.`
+			)
+			.setColor("BLUE");
 
-    const checkMark = "✅";
-    const filter = (r, u) =>
-      r.emoji.name === checkMark && u.id === message.author.id;
+		const checkMark = "✅";
+		const filter = (r, u) => r.emoji.name === checkMark && u.id === message.author.id;
 
-    const msg = await message.channel.send({ embed });
-    await msg.react(checkMark);
-    try {
-      await msg.awaitReactions(filter, {
-        time: 30000,
-        max: 1,
-        errors: ["time"]
-      });
-      userParameters.forEach(parameter => {
-        message.author.changeSetting(parameter, "on");
-      });
-    } catch (err) {
-      msg.reactions.removeAll();
-      msg.edit(`The operation has been cancelled.`);
-      throw err;
-    }
-  }
+		const msg = await message.channel.send({ embed });
+		await msg.react(checkMark);
+		try {
+			await msg.awaitReactions(filter, {
+				time: 30000,
+				max: 1,
+				errors: ["time"]
+			});
+			userParameters.forEach(parameter => {
+				message.author.changeSetting(parameter, "on");
+			});
+		} catch (err) {
+			msg.reactions.removeAll();
+			msg.edit("The operation has been cancelled.");
+			throw err;
+		}
+	}
 
-  done(message) {
-    const { prefix } = message.guild;
-    const embed = new MessageEmbed()
-      .setTitle("Done!")
-      .setDescription(
-        "Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health." +
-          "\n" +
-          `You can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
-      )
-      .setColor("GREEN");
-    message.channel.send({ embed });
-  }
+	done(message) {
+		const { prefix } = message.guild;
+		const embed = new MessageEmbed()
+			.setTitle("Done!")
+			.setDescription(
+				"Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health."
+          + "\n"
+          + `You can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
+			)
+			.setColor("GREEN");
+		message.channel.send({ embed });
+	}
 
-  noPermissions(message) {
-    const { prefix } = message.guild;
-    const embed = new MessageEmbed()
-      .setTitle("Oops!")
-      .setDescription(
-        `This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
-      )
-      .setColor("RED");
-    message.channel.send({ embed });
-  }
+	noPermissions(message) {
+		const { prefix } = message.guild;
+		const embed = new MessageEmbed()
+			.setTitle("Oops!")
+			.setDescription(
+				`This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
+			)
+			.setColor("RED");
+		message.channel.send({ embed });
+	}
 
-  // eslint-disable-next-line class-methods-use-this
-  async run(bot, message, args) {
-    const isAdmin = message.member
-      .permissionsIn(message.channel)
-      .has("Administrator");
+	// eslint-disable-next-line class-methods-use-this
+	async run(bot, message, args) {
+		const isAdmin = message.member
+			.permissionsIn(message.channel)
+			.has("Administrator");
 
-    const guildEnabled = guildParameters.every(parameter => {
-      return message.guild.settings[parameter] === "on";
-    });
-    const userEnabled = userParameters.every(parameter => {
-      return message.author.settings[parameter] === "on";
-    });
+		const guildEnabled = guildParameters.every(parameter => message.guild.settings[parameter] === "on");
+		const userEnabled = userParameters.every(parameter => message.author.settings[parameter] === "on");
 
-    // This is what I could think of for making it stop immediately if one of the functions
-    // time out. A side effect is that errors here aren't caught properly. How does one tell a timer error
-    // from a regular error with the code?
-    // (Please don't approve this PR without thinking over it a little bit.)
-    try {
-      if (isAdmin) {
-        if (!guildEnabled && !userEnabled) {
-          await this.setGuildSettings(message);
-          await this.setUserSettings(message);
-          this.done(message);
-        } else if (!guildEnabled) {
-          await this.setGuildSettings(message);
-          this.done(message);
-        } else if (!userEnabled) {
-          await this.setUserSettings(message);
-          this.done(message);
-        } else {
-          this.done(message);
-        }
-      }
-      if (!isAdmin) {
-        if (!guildEnabled) {
-          this.noPermissions(message);
-        } else if (!userEnabled) {
-          await this.setUserSettings(message);
-          this.done(message);
-        } else {
-          this.done(message);
-        }
-      }
-    } catch (err) {
-      return;
-    }
-  }
+		// This is what I could think of for making it stop immediately if one of the functions
+		// time out. A side effect is that errors here aren't caught properly. How does one tell a timer error
+		// from a regular error with the code?
+		// (Please don't approve this PR without thinking over it a little bit.)
+		try {
+			if (isAdmin) {
+				if (!guildEnabled && !userEnabled) {
+					await this.setGuildSettings(message);
+					await this.setUserSettings(message);
+					this.done(message);
+				} else if (!guildEnabled) {
+					await this.setGuildSettings(message);
+					this.done(message);
+				} else if (!userEnabled) {
+					await this.setUserSettings(message);
+					this.done(message);
+				} else {
+					this.done(message);
+				}
+			}
+			if (!isAdmin) {
+				if (!guildEnabled) {
+					this.noPermissions(message);
+				} else if (!userEnabled) {
+					await this.setUserSettings(message);
+					this.done(message);
+				} else {
+					this.done(message);
+				}
+			}
+		} catch (err) {
+
+		}
+	}
 };

--- a/Commands/settings/enabledrpg.js
+++ b/Commands/settings/enabledrpg.js
@@ -7,149 +7,160 @@ const guildParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
 const userParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
 
 module.exports = class EnableDRPGCommand extends Command {
-    constructor (client) {
-        super(client, {
-            name: "enabledrpg",
-            description: "Utility command to enable configuration values for DiscordRPG usage",
-        });
+  constructor(client) {
+    super(client, {
+      name: "enabledrpg",
+      description:
+        "Utility command to enable configuration values for DiscordRPG usage"
+    });
+  }
+
+  async setGuildSettings(message) {
+    const { prefix } = message.guild;
+
+    const embed = new MessageEmbed()
+      .setTitle("Configuring Guild Settings")
+      .setDescription(
+        "**This will enable the following Guild settings:**\n" +
+          "DRPG Health Monitor - `healthMonitor`" +
+          "\n" +
+          "DRPG Adventure Timer - `adventureTimer`" +
+          "\n" +
+          "DRPG Sides Timer - `sidesTimer`" +
+          "\n" +
+          `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}gconfig\`.`
+      )
+      .setColor("BLUE");
+    const checkMark = "✅";
+    const filter = (r, u) =>
+      r.emoji.name === checkMark && u.id === message.author.id;
+
+    const msg = await message.channel.send({ embed });
+    await msg.react(checkMark);
+    try {
+      await msg.awaitReactions(filter, {
+        time: 30000,
+        max: 1,
+        errors: ["time"]
+      });
+      guildParameters.forEach(parameter => {
+        message.guild.changeSetting(parameter, "on");
+      });
+    } catch (err) {
+      msg.reactions.removeAll();
+      msg.edit(`The operation has been cancelled.`);
+      throw err;
     }
+  }
 
-    async setGuildSettings (message) {
-        const { prefix } = message.guild;
+  async setUserSettings(message) {
+    const { prefix } = message.guild;
 
-        const embed = new MessageEmbed()
-            .setTitle("Configuring Guild Settings")
-            .setDescription(
-                "**This will enable the following Guild settings:**\n" + 
-                "DRPG Health Monitor - `healthMonitor`" + "\n" +
-                "DRPG Adventure Timer - `adventureTimer`" + "\n" +
-                "DRPG Sides Timer - `sidesTimer`" + "\n" +
-                `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}gconfig\`.`
-            )
-            .setColor("BLUE");
-        const checkMark = "✅";
-        const filter = (r, u) => r.emoji.name === checkMark && u.id === message.author.id;
+    const embed = new MessageEmbed()
+      .setTitle("Configuring User Settings")
+      .setDescription(
+        "**This will enable the following User settings:**\n" +
+          "DRPG Health Monitor - `healthMonitor`" +
+          "\n" +
+          "DRPG Adventure Timer - `adventureTimer`" +
+          "\n" +
+          "DRPG Sides Timer - `sidesTimer`" +
+          "\n" +
+          `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}uconfig\`.`
+      )
+      .setColor("BLUE");
 
-        const msg = await message.channel.send({ embed });
-        await msg.react(checkMark);
-        try {
-            await msg.awaitReactions(filter, { time: 30000, max: 1, errors: ["time"] });
-            guildParameters.forEach(parameter => {
-                message.guild.changeSetting(parameter, "on");
-            });
-        }
-        catch (err) {
-            msg.reactions.removeAll();
-            msg.edit(`The operation has been cancelled.`);
-            throw err;
-        }
+    const checkMark = "✅";
+    const filter = (r, u) =>
+      r.emoji.name === checkMark && u.id === message.author.id;
+
+    const msg = await message.channel.send({ embed });
+    await msg.react(checkMark);
+    try {
+      await msg.awaitReactions(filter, {
+        time: 30000,
+        max: 1,
+        errors: ["time"]
+      });
+      userParameters.forEach(parameter => {
+        message.author.changeSetting(parameter, "on");
+      });
+    } catch (err) {
+      msg.reactions.removeAll();
+      msg.edit(`The operation has been cancelled.`);
+      throw err;
     }
+  }
 
+  done(message) {
+    const { prefix } = message.guild;
+    const embed = new MessageEmbed()
+      .setTitle("Done!")
+      .setDescription(
+        "Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health." +
+          "\n" +
+          `You can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
+      )
+      .setColor("GREEN");
+    message.channel.send({ embed });
+  }
 
-    async setUserSettings (message) {
-        const { prefix } = message.guild;
+  noPermissions(message) {
+    const { prefix } = message.guild;
+    const embed = new MessageEmbed()
+      .setTitle("Oops!")
+      .setDescription(
+        `This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
+      )
+      .setColor("RED");
+    message.channel.send({ embed });
+  }
 
-        const embed = new MessageEmbed()
-        .setTitle("Configuring User Settings")
-        .setDescription(
-            "**This will enable the following User settings:**\n" + 
-            "DRPG Health Monitor - `healthMonitor`" + "\n" +
-            "DRPG Adventure Timer - `adventureTimer`" + "\n" +
-            "DRPG Sides Timer - `sidesTimer`" + "\n" +
-            `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}uconfig\`.`
-        )
-        .setColor("BLUE");
+  // eslint-disable-next-line class-methods-use-this
+  async run(bot, message, args) {
+    const isAdmin = message.member
+      .permissionsIn(message.channel)
+      .has("Administrator");
 
-        const checkMark = "✅";
-        const filter = (r, u) => r.emoji.name === checkMark && u.id === message.author.id;
+    const guildEnabled = guildParameters.every(parameter => {
+      return message.guild.settings[parameter] === "on";
+    });
+    const userEnabled = userParameters.every(parameter => {
+      return message.author.settings[parameter] === "on";
+    });
 
-        const msg = await message.channel.send({ embed });
-        await msg.react(checkMark);
-        try {
-            await msg.awaitReactions(filter, { time: 30000, max: 1, errors: ["time"] });
-            userParameters.forEach(parameter => {
-                message.author.changeSetting(parameter, "on");
-            });
+    // This is what I could think of for making it stop immediately if one of the functions
+    // time out. A side effect is that errors here aren't caught properly. How does one tell a timer error
+    // from a regular error with the code?
+    // (Please don't approve this PR without thinking over it a little bit.)
+    try {
+      if (isAdmin) {
+        if (!guildEnabled && !userEnabled) {
+          await this.setGuildSettings(message);
+          await this.setUserSettings(message);
+          this.done(message);
+        } else if (!guildEnabled) {
+          await this.setGuildSettings(message);
+          this.done(message);
+        } else if (!userEnabled) {
+          await this.setUserSettings(message);
+          this.done(message);
+        } else {
+          this.done(message);
         }
-       catch (err) {
-            msg.reactions.removeAll();
-            msg.edit(`The operation has been cancelled.`);
-            throw err;
+      }
+      if (!isAdmin) {
+        if (!guildEnabled) {
+          this.noPermissions(message);
+        } else if (!userEnabled) {
+          await this.setUserSettings(message);
+          this.done(message);
+        } else {
+          this.done(message);
         }
+      }
+    } catch (err) {
+      return;
     }
-
-    done (message) {
-        const { prefix } = message.guild;
-        const embed = new MessageEmbed()
-            .setTitle("Done!")
-            .setDescription(
-                "Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health." + "\n" +
-                `You can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
-            )
-            .setColor("GREEN");
-        message.channel.send({ embed });
-    }
-
-    noPermissions (message) {
-        const { prefix } = message.guild;
-        const embed = new MessageEmbed()
-            .setTitle("Oops!")
-            .setDescription(
-                `This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
-            )
-            .setColor("RED");
-        message.channel.send({ embed });
-    }
-
-	// eslint-disable-next-line class-methods-use-this
-    async run (bot, message, args) {
-        const isAdmin = message.member.permissionsIn(message.channel).has("Administrator");
-
-        const guildEnabled = guildParameters.every(parameter => {
-            return message.guild.settings[parameter] === "on";
-        });
-        const userEnabled = userParameters.every(parameter => {
-            return message.author.settings[parameter] === "on";
-        });
-
-        // This is what I could think of for making it stop immediately if one of the functions
-        // time out. A side effect is that errors here aren't caught properly. How does one tell a timer error
-        // from a regular error with the code?
-        // (Please don't approve this PR without thinking over it a little bit.)
-        try {
-            if (isAdmin) {
-                if (!guildEnabled && !userEnabled) {
-                    await this.setGuildSettings(message);
-                    await this.setUserSettings(message);
-                    this.done(message);
-                }
-                else if (!guildEnabled) {
-                    await this.setGuildSettings(message);
-                    this.done(message);
-                }
-                else if (!userEnabled) {
-                    await this.setUserSettings(message);
-                    this.done(message);
-                }
-                else {
-                    this.done(message);
-                }
-            }
-            if (!isAdmin) {
-                if (!guildEnabled) {
-                    this.noPermissions(message);
-                }
-                else if (!userEnabled) {
-                    await this.setUserSettings(message);
-                    this.done(message);
-                }
-                else {
-                    this.done(message);
-                }
-            }
-        }
-        catch (err) {
-            return;
-        }
-    }
-}
+  }
+};

--- a/Commands/settings/enabledrpg.js
+++ b/Commands/settings/enabledrpg.js
@@ -1,0 +1,151 @@
+const { MessageEmbed } = require("discord.js");
+const { Command } = require("../../structures/categories/SettingsCategory");
+
+// I'm too dumb to think of how to define these constants in a function
+// Please tell me where these should go honestly
+const guildParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
+const userParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
+
+module.exports = class EnableDRPGCommand extends Command {
+    constructor (client) {
+        super(client, {
+            name: "enabledrpg",
+            description: "Utility command to enable configuration values for DiscordRPG usage",
+        });
+    }
+
+    async setGuildSettings (message) {
+        const { prefix } = message.guild;
+
+        const embed = new MessageEmbed()
+            .setTitle("Configuring Guild Settings")
+            .setDescription(
+                "**This will enable the following Guild settings:**\n" + 
+                "DRPG Health Monitor - `healthMonitor`" + "\n" +
+                "DRPG Adventure Timer - `adventureTimer`" + "\n" +
+                "DRPG Sides Timer - `sidesTimer`" + "\n" +
+                `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}gconfig\`.`
+            )
+            .setColor("BLUE");
+        const checkMark = "✅";
+        const filter = (r, u) => r.emoji.name === checkMark && u.id === message.author.id;
+
+        const msg = await message.channel.send({ embed });
+        await msg.react(checkMark);
+        try {
+            await msg.awaitReactions(filter, { time: 30000, max: 1, errors: ["time"] });
+            guildParameters.forEach(parameter => {
+                message.guild.changeSetting(parameter, "on");
+            });
+        }
+        catch (err) {
+            msg.reactions.removeAll();
+            msg.edit(`The operation has been cancelled.`);
+            throw err;
+        }
+    }
+
+
+    async setUserSettings (message) {
+        const { prefix } = message.guild;
+
+        const embed = new MessageEmbed()
+        .setTitle("Configuring User Settings")
+        .setDescription(
+            "**This will enable the following User settings:**\n" + 
+            "DRPG Health Monitor - `healthMonitor`" + "\n" +
+            "DRPG Adventure Timer - `adventureTimer`" + "\n" +
+            "DRPG Sides Timer - `sidesTimer`" + "\n" +
+            `**Do you want to proceed?** Click :white_check_mark: to continue. You can always configure the settings in \`${prefix}uconfig\`.`
+        )
+        .setColor("BLUE");
+
+        const checkMark = "✅";
+        const filter = (r, u) => r.emoji.name === checkMark && u.id === message.author.id;
+
+        const msg = await message.channel.send({ embed });
+        await msg.react(checkMark);
+        try {
+            await msg.awaitReactions(filter, { time: 30000, max: 1, errors: ["time"] });
+            userParameters.forEach(parameter => {
+                message.author.changeSetting(parameter, "on");
+            });
+        }
+       catch (err) {
+            msg.reactions.removeAll();
+            msg.edit(`The operation has been cancelled.`);
+            throw err;
+        }
+    }
+
+    done (message) {
+        const { prefix } = message.guild;
+        const embed = new MessageEmbed()
+            .setTitle("Done!")
+            .setDescription(
+                "Aldebaran's DRPG features are now enabled. Feel free to use DRPG normally. Aldebaran will respond appropriately when your adventure and sides are ready, and when you have low health." + "\n" +
+                `You can always turn off features in \`${prefix}uconfig\` and \`${prefix}gconfig\`.`
+            )
+            .setColor("GREEN");
+        message.channel.send({ embed });
+    }
+
+    noPermissions (message) {
+        const { prefix } = message.guild;
+        const embed = new MessageEmbed()
+            .setTitle("Oops!")
+            .setDescription(
+                `This guild's administrators have not set their guild settings to enable DRPG. Please ask them to run \`${prefix}enabledrpg\`.`
+            )
+            .setColor("RED");
+        message.channel.send({ embed });
+    }
+
+	// eslint-disable-next-line class-methods-use-this
+    async run (bot, message, args) {
+        const isAdmin = message.member.permissionsIn(message.channel).has("Administrator");
+
+        const guildEnabled = guildParameters.every(parameter => {
+            return message.guild.settings[parameter] === "on";
+        });
+        const userEnabled = userParameters.every(parameter => {
+            return message.author.settings[parameter] === "on";
+        });
+
+        // This is what I could think of for making it stop immediately if one of the functions
+        // time out. A side effect is that errors here aren't caught properly. How does one tell a timer error
+        // from a regular error with the code?
+        // (Please don't approve this PR without thinking over it a little bit.)
+        try {
+            if (isAdmin) {
+                if (!guildEnabled && !userEnabled) {
+                    await this.setGuildSettings(message);
+                    await this.setUserSettings(message);
+                    this.done(message);
+                }
+                else if (!userEnabled) {
+                    await this.setUserSettings(message);
+                    this.done(message);
+                }
+                else {
+                    this.done(message);
+                }
+            }
+            if (!isAdmin) {
+                if (!guildEnabled) {
+                    this.noPermissions(message);
+                }
+                else if (!userEnabled) {
+                    await this.setUserSettings(message);
+                    this.done(message);
+                }
+                else {
+                    this.done(message);
+                }
+            }
+        }
+        catch (err) {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
This pull request:

* Adds the &enabledrpg command that sets the Aldebaran settings of the guild (if administrator) and user (if unset) to enable Aldebaran's DRPG features. This is for the ease of use of new users.

There are code issues that I wish to address (namely errors not being caught properly) because I do not know how a Timer error can be caught differently from a regular error. A side effect is that if an error occurs in this command it will not be detected properly. **Do not merge this before resolving this problem.**