### PR TITLE
Use npm run dev 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "start": "node bot.js",
-    "test": "node bot.js dev !",
+    "dev": "node bot.js dev !",
     "sos": "node bot.js sos",
     "configure": "node bin/configure.js"
   },


### PR DESCRIPTION
Initially I set the NPM script for running the bot in Dev mode to `npm test`. This was made out of ignorance. I now realize that `npm test` is meant for Test-Driven Development and not a general command. This PR sets the script for running the bot to `npm run dev`. While it is more to type, it is also more correct. 