### PR TITLE
1.11.15 - General Improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
         "semi": ["error", "always"],
         "quotes": ["warn", "double"],
         "object-curly-spacing": ["error", "always"],
+        "object-curly-newline": "off",
         "comma-dangle": ["error", "never"],
         "no-tabs": ["error", { "allowIndentationTabs": true }],
         "linebreak-style": "off",

--- a/assets/data/categories.json
+++ b/assets/data/categories.json
@@ -12,9 +12,9 @@
     "drpg": {
         "name": "DiscordRPG",
         "title": "<:drpg:608217182362533898> DiscordRPG <:drpg:608217182362533898>",
-        "description": "Utility commands for DiscordRPG",
-        "aliases": ["discordrpg"]
+        "description": "Utility commands for DiscordRPG"
     },
+    "discordrpg": "drpg",
     "fun": {
         "name": "Fun",
         "title": ":tickets: Fun :performing_arts:",
@@ -27,7 +27,7 @@
     },
     "games": {
         "name": "Games",
-        "title": "::joystick: Games :tv:",
+        "title": ":joystick: Games :tv:",
         "description": "Games through commands!"
     },
     "image": {

--- a/src/commands/developer/serverlist.js
+++ b/src/commands/developer/serverlist.js
@@ -18,7 +18,7 @@ module.exports = class ServerlistCommand extends Command {
 		const list = [];
 		let chunk = 0;
 		let guildIndex = 0;
-		bot.guilds.forEach(guild => {
+		bot.guilds.cache.forEach(guild => {
 			if (guildIndex === 20) {
 				chunk++;
 				guildIndex = 0;

--- a/src/commands/drpg/plantcalc.js
+++ b/src/commands/drpg/plantcalc.js
@@ -20,10 +20,12 @@ module.exports = class PlantcalcCommand extends Command {
 			let item = null;
 			for (const element of Object.values(itemList))
 				if (element.name.toLowerCase() === itemName) item = element;
-			const scope = { luck: points, passed: hours * 3600 };
-			const min = math.eval(item.sapling.loot.amount.min, scope);
-			const max = math.eval(item.sapling.loot.amount.max, scope);
-			message.channel.send(`Estimated ${min} - ${max} when planted for ${hours} hours. `);
+			if (item.sapling) {
+				const scope = { luck: points, passed: hours * 3600 };
+				const min = math.eval(item.sapling.loot.amount.min, scope);
+				const max = math.eval(item.sapling.loot.amount.max, scope);
+				message.channel.send(`Estimated ${min} - ${max} when planted for ${hours} hours. `);
+			} else message.channel.error("WRONG_USAGE", "You need to provide the name of a valid sapling.");
 		} else message.channel.send("You must provide reaping points, hours set and item name. Example (&plantcalc 1 24 olive)");
 	}
 };

--- a/src/commands/drpg/skills.js
+++ b/src/commands/drpg/skills.js
@@ -49,20 +49,29 @@ module.exports = class SkillsCommand extends Command {
 					const forageMax = 1 + skillinfo.forage.level
 						+ Math.floor(maxpoints / 65);
 
+					const xpCalc = level => [
+						Math.round(Math.sqrt((Math.sqrt(level) * 0.25) * 15 / 2)),
+						Math.round(Math.sqrt((Math.sqrt(level) * 0.25) * 5 / 2))
+					];
 					const xp = level => {
-						const max = Math
-							.round(Math.sqrt((Math.sqrt(level) * 0.25) * 15 / 2));
-						const min = Math
-							.round(Math.sqrt((Math.sqrt(level) * 0.25) * 5 / 2));
+						const [max, min] = xpCalc(level);
 						return `You would get between **${min} and ${max} skill XP**.`;
+					};
+					const mineXp = level => {
+						const [max, min] = xpCalc(level);
+						const minMin = min + Math.floor(attribs.mineBoost / 125);
+						const minMax = max + Math.floor(attribs.mineBoost / 125);
+						const maxMin = min + Math.floor(maxpoints / 125);
+						const maxMax = max + Math.floor(maxpoints / 125);
+						return `With your current mining boosts skills, you would get between **${minMin} and ${minMax} skill XP**.\nWith the highest mining boosts skills, you would get between **${maxMin} and ${maxMax} skill XP**.`;
 					};
 					const embed = new MessageEmbed()
 						.setAuthor(`${user.username}  |  Skills`, user.avatarURL())
 						.setColor(0x00AE86)
-						.addField("Mining", `**Level ${skillinfo.mine.level}** (${Number.formatNumber(skillinfo.mine.xp)} XP)\nWith your **current** mining boost skills, you would get **${miningCurrent} ores or essences**.\nWith the **highest** mining boost skills, you would get **${miningMax} ores**, or between **${essenceMax} and ${miningMax} essences**.\n${xp(skillinfo.mine.level)}`)
-						.addField("Chopping", `**Level ${skillinfo.chop.level}** (${Number.formatNumber(skillinfo.chop.xp)} XP)\nWith your **current** lumber boost skills, you would get **${lumbercurrent} logs**.\nWith the **highest** lumber boost skills, you would get **${lumbermax} logs**.\n${xp(skillinfo.mine.level)}`)
-						.addField("Foraging", `**Level ${skillinfo.forage.level}** (${Number.formatNumber(skillinfo.forage.xp)} XP)\nWith your **current** scavenging skills, you would get **${forageCurrent} items**.\nWith the **highest** scavenging skills, you would get **${forageMax} items**.\n${xp(skillinfo.mine.level)}`)
-						.addField("Fishing", `**Level ${skillinfo.fish.level}** (${Number.formatNumber(skillinfo.fish.xp)} XP)\n${xp(skillinfo.mine.level)}`);
+						.addField("Mining", `**Level ${skillinfo.mine.level}** (${Number.formatNumber(skillinfo.mine.xp)} XP)\nWith your **current** mining boost skills, you would get **${miningCurrent} ores or essences**.\nWith the **highest** mining boost skills, you would get **${miningMax} ores**, or between **${essenceMax} and ${miningMax} essences**.\n${mineXp(skillinfo.mine.level)}`)
+						.addField("Chopping", `**Level ${skillinfo.chop.level}** (${Number.formatNumber(skillinfo.chop.xp)} XP)\nWith your **current** lumber boost skills, you would get **${lumbercurrent} logs**.\nWith the **highest** lumber boost skills, you would get **${lumbermax} logs**.\n${xp(skillinfo.chop.level)}`)
+						.addField("Foraging", `**Level ${skillinfo.forage.level}** (${Number.formatNumber(skillinfo.forage.xp)} XP)\nWith your **current** scavenging skills, you would get **${forageCurrent} items**.\nWith the **highest** scavenging skills, you would get **${forageMax} items**.\n${xp(skillinfo.forage.level)}`)
+						.addField("Fishing", `**Level ${skillinfo.fish.level}** (${Number.formatNumber(skillinfo.fish.xp)} XP)\n${xp(skillinfo.fish.level)}`);
 					message.channel.send(embed);
 				}
 			});

--- a/src/commands/fun/emojilist.js
+++ b/src/commands/fun/emojilist.js
@@ -9,8 +9,10 @@ module.exports = class EmojilistCommand extends Command {
 
 	// eslint-disable-next-line class-methods-use-this
 	run(bot, message) {
-		const emojilist = message.guild.emojis.map(e => e.toString()).join("");
+		const emojilist = message.guild.emojis.cache.map(e => e.toString()).join("");
 		message.delete();
-		message.channel.send(emojilist);
+		if (emojilist.length <= 2000)
+			message.channel.send(emojilist);
+		else message.channel.error("IMPOSSIBLE", "There are too many emojis on this server to show in a single message.");
 	}
 };

--- a/src/commands/general/help.js
+++ b/src/commands/general/help.js
@@ -11,7 +11,8 @@ module.exports = class HelpCommand extends Command {
 
 	run(bot, message, args) {
 		if (args[0] !== undefined) {
-			const category = categories[args[0].toLowerCase()];
+			const match = categories[args[0].toLowerCase()];
+			const category = typeof match === "string" ? categories[match] : match;
 			if (category !== undefined) {
 				let list = "";
 				const categoryCommands = new Map();

--- a/src/commands/general/user.js
+++ b/src/commands/general/user.js
@@ -90,6 +90,6 @@ module.exports = class UserCommand extends Command {
 			if (allPermissions.length > 0)
 				embed.addField("Permissions", allPermissions.join(", "));
 			message.channel.send({ embed });
-		}).catch(err => { throw err; });
+		}).catch(() => { message.channel.error("INVALID_USER"); });
 	}
 };

--- a/src/commands/image/birb.js
+++ b/src/commands/image/birb.js
@@ -8,7 +8,7 @@ module.exports = class BirbCommand extends Command {
 
 	run(bot, message) {
 		request({ uri: "http://random.birb.pw/tweet.json/" }, (err, response, body) => {
-			if (err) return message.channel.send("This seems to be a birb problem");
+			if (err || response.statusCode !== 200) return message.channel.send("This seems to be a birb problem");
 			const embed = new Embed(this)
 				.setTitle("You want some __Birb__?")
 				.setImage(`http://random.birb.pw/img/${JSON.parse(body).file}`)

--- a/src/commands/image/randimal.js
+++ b/src/commands/image/randimal.js
@@ -17,11 +17,11 @@ module.exports = class RandimalCommand extends Command {
 			const parsed = JSON.parse(body);
 			if (err) return message.channel.send("This seems to be a problem");
 			if (parsed.error) return message.channel.send("Someone has requested too many animals recently, the only thing you can do is waiting for your turn!");
-			const [data] = parsed.photos[0];
+			const { src, photographer } = parsed.photos[0];
 			const embed = new Embed(this)
 				.setTitle("**__Virtual Safari__**")
-				.setImage(data.src.large)
-				.setFooter(`Virtual Safari Powered By: ${data.photographer} on Pexels.com`);
+				.setImage(src.large)
+				.setFooter(`Virtual Safari Powered By: ${photographer} on Pexels.com`);
 			return message.channel.send({ embed });
 		});
 	}

--- a/src/commands/settings/customtimer.js
+++ b/src/commands/settings/customtimer.js
@@ -6,6 +6,7 @@ module.exports = class CustomTimerCommand extends Command {
 	constructor(client) {
 		super(client, {
 			description: "Manages your custom timers",
+			help: "**`&customtimer create`** - Creates a custom timer\n**`&customtimer list`** - Lists your active custom timers\n**`&customtimer delete`** - Deletes the specified custom timer\nThis command allows you to create custom timers. Custom timers are a way for you to be reminded of something every x period of time. For now, this reminder is repeated 10 times; then, it automatically self-destroys. To create a custom timer that reminds you to pet your cat every 5 minutes, use `&customtimer create 5m pet my cat`. If you want to be reminded in the channel in which you are creating the custom timer, add `-c` at the end of the command. If you want to delete the custom timer, use `&customtimer list`, which will give you the list of your active custom timers, look at the ID of the custom timer you want to delete and use `&customtimer delete 60`, if the ID of your custom timer is 60.",
 			usage: "Action",
 			example: "create",
 			aliases: ["ct"]
@@ -25,16 +26,18 @@ module.exports = class CustomTimerCommand extends Command {
 					const channelId = args.includes("-c") ? message.channel.id : null;
 					if (channelId !== null) args.splice(args.indexOf("-c"), 1);
 					if (timer !== null) {
-						timer = timer.reduce((time, str) => time + Number(str.match(/(\d+)\s*([dhms])/i)[1]) * times[RegExp.$2], 0);
+						timer = timer.reduce((time, str) => time + Number(str.match(/(\d+)\s*([dhms])/i)[1]) * times[RegExp.$2], 0); // Parse the interval
 						if (timer < 10000) message.channel.error("WRONG_USAGE", "You cannot set a custom timer with an interval lower than 10 seconds.");
-						// eslint-disable-next-line no-new
-						new CustomTimer(bot, {
+						CustomTimer.create(bot, { // Start the custom timer creation process
 							userId: message.author.id,
 							timer,
 							channelId,
 							content: args.join(" ")
+						}).then(() => {
+							message.channel.send("Your custom timer has been set!");
+						}).catch(err => {
+							message.channel.error("UNEXPECTED_BEHAVIOR", `An unexpected error occured and your custom timer could not be created.\n> ${err.message}`);
 						});
-						message.channel.send("Your custom timer has been set!");
 					} else message.reply("the timer timeout is invalid, it needs to be in the following format: `1337d`, d meaning \"day\", being replaced by s for \"seconds\", m for \"minutes\" and h for \"hours\".");
 				} else message.reply("you need to specify the timer timeout, its content and if the timer should be shown in the current channel instead of in your DMs (-c)");
 			} else if (args[0].toLowerCase() === "delete") {

--- a/src/commands/settings/customtimer.js
+++ b/src/commands/settings/customtimer.js
@@ -16,7 +16,7 @@ module.exports = class CustomTimerCommand extends Command {
 	run(bot, message, args) {
 		if (args[0] !== undefined) {
 			if (args[0].toLowerCase() === "create") {
-				if (args.length > 3) {
+				if (args.length >= 3) {
 					args.shift();
 					const times = {
 						d: 86400000, h: 3600000, m: 60000, s: 1000
@@ -26,6 +26,7 @@ module.exports = class CustomTimerCommand extends Command {
 					if (channelId !== null) args.splice(args.indexOf("-c"), 1);
 					if (timer !== null) {
 						timer = timer.reduce((time, str) => time + Number(str.match(/(\d+)\s*([dhms])/i)[1]) * times[RegExp.$2], 0);
+						if (timer < 10000) message.channel.error("WRONG_USAGE", "You cannot set a custom timer with an interval lower than 10 seconds.");
 						// eslint-disable-next-line no-new
 						new CustomTimer(bot, {
 							userId: message.author.id,

--- a/src/commands/utilities/curconv.js
+++ b/src/commands/utilities/curconv.js
@@ -29,8 +29,8 @@ module.exports = class CurConvCommand extends Command {
 	}
 
 	convCurToAnotherCur(fromCurrency, toCurrency, value) {
-		this.fromCurrency = fromCurrency;
-		this.toCurrency = toCurrency;
+		this.fromCurrency = fromCurrency.toUpperCase();
+		this.toCurrency = toCurrency.toUpperCase();
 		this.value = parseInt(value, 10);
 		try {
 			request(
@@ -56,11 +56,10 @@ module.exports = class CurConvCommand extends Command {
 			);
 			this.message.channel.error("API_ERROR", `Fixer responded with an error. Try again later. Error: ${data.error.type}`);
 			return false;
-		} else if (data.success) {
-			if (!data.rates[this.fromCurrency] || !data.rates[this.toCurrency]) {
-				this.message.channel.error("WRONG_USAGE", `The specified currency, ${this.fromCurrency}, does not exist.`);
-				return false;
-			}
+		} else if (!data.rates[this.fromCurrency] || !data.rates[this.toCurrency]) {
+			if (!data.rates[this.fromCurrency]) this.message.channel.error("WRONG_USAGE", `The specified currency, ${this.fromCurrency}, does not exist.`);
+			else if (!data.rates[this.toCurrency]) this.message.channel.error("WRONG_USAGE", `The specified currency, ${this.toCurrency}, does not exist.`);
+			return false;
 		}
 		return true;
 	}
@@ -88,13 +87,10 @@ module.exports = class CurConvCommand extends Command {
 
 			const str = `**${this.value.toFixed(2)} ${this.fromCurrency}** is equal to **${valueInTarget.toFixed(2)} ${this.toCurrency}** as of ${getDate(data.timestamp * 1000)}, with a **${rate.toFixed(2)} rate**.`;
 
-			this.message.channel.send(
-				new Embed(this)
-					.setTitle(
-						`Conversion from ${this.fromCurrency} to ${this.toCurrency}`
-					)
-					.setDescription(str)
-			);
+			const embed = new Embed(this)
+				.setTitle(`Conversion from ${this.fromCurrency} to ${this.toCurrency}`)
+				.setDescription(str);
+			this.message.channel.send({ embed });
 		}
 	}
 

--- a/src/groups/ActionCommand.js
+++ b/src/groups/ActionCommand.js
@@ -3,8 +3,8 @@ const { Command, Embed } = require("./Command");
 module.exports.Command = class ActionCommand extends Command {
 	constructor(client, metadata) {
 		super(client, {
-			...metadata,
-			args: { user: { as: "user" } }
+			args: { user: { as: "user" } },
+			...metadata
 		});
 		this.category = "Action";
 		this.color = "AQUA";

--- a/src/groups/Command.js
+++ b/src/groups/Command.js
@@ -22,7 +22,7 @@ module.exports.Command = class Command {
    * @param {string[]} metadata.perms.aldebaran Aldebaran required permissions
    */
 	constructor(client, metadata) {
-		if (this.constructor === "Command") {
+		if (this.constructor.name === "Command") {
 			throw new TypeError(
 				"Command is an abstract class and therefore cannot be instantiated."
 			);

--- a/src/groups/DeveloperCommand.js
+++ b/src/groups/DeveloperCommand.js
@@ -3,10 +3,10 @@ const { Command } = require("./Command");
 module.exports.Command = class DeveloperCategory extends Command {
 	constructor(client, metadata) {
 		super(client, {
-			...metadata,
 			perms: metadata.perms === undefined
 				? { aldebaran: ["ADMINISTRATOR"] }
-				: { ...metadata.perms }
+				: { ...metadata.perms },
+			...metadata
 		});
 		this.category = "Developer";
 	}

--- a/src/groups/OsuCommand.js
+++ b/src/groups/OsuCommand.js
@@ -3,12 +3,12 @@ const { Command, Embed } = require("./Command");
 module.exports.Command = class OsuCategory extends Command {
 	constructor(client, metadata) {
 		super(client, {
-			...metadata,
 			cooldown: {
 				group: "osu",
 				amount: 60,
 				resetInterval: 60000
-			}
+			},
+			...metadata
 		});
 		this.category = "osu!";
 		this.color = "#ff66aa";

--- a/src/structures/aldebaran/CustomTimer.js
+++ b/src/structures/aldebaran/CustomTimer.js
@@ -76,7 +76,7 @@ module.exports = class CustomTimer {
 		const user = await this.client.users.fetch(this.userId);
 		if (this.channelId === null) {
 			user.send(`Here is your reminder${this.content !== null ? ` for **${this.content}**` : ""}!${late ? "\n*This reminder is late due to the bot being down. Sorry for the inconvenience.*" : ""}`).catch(this.delete);
-		} else this.client.channels.get(this.channelId).send(`<@${this.userId}>, here is your reminder${this.content !== null ? ` for **${this.content}**` : ""}!${late ? "\n*This reminder is late due to the bot being down. Sorry for the inconvenience.*" : ""}`).catch(this.delete);
+		} else this.client.channels.cache.get(this.channelId).send(`<@${this.userId}>, here is your reminder${this.content !== null ? ` for **${this.content}**` : ""}!${late ? "\n*This reminder is late due to the bot being down. Sorry for the inconvenience.*" : ""}`).catch(this.delete);
 	}
 
 	async delete() {

--- a/src/structures/aldebaran/CustomTimer.js
+++ b/src/structures/aldebaran/CustomTimer.js
@@ -1,5 +1,5 @@
 module.exports = class CustomTimer {
-	constructor(client, data) {
+	constructor(client, data, first = false) {
 		this.id = data.id;
 		this.client = client;
 		this.userId = data.userId;
@@ -8,35 +8,24 @@ module.exports = class CustomTimer {
 		this.trigger = data.trigger || null;
 		this.timer = data.timer;
 		this.occurences = data.occurences || 10;
-		this.remind = data.remind;
-		if (this.id === undefined) {
-			if (this.userId === undefined
-				|| this.content === null
-				|| this.timer === null
-			) return new TypeError("INVALID_DATA");
-			this.remind = Date.now();
-			this.create(
-				this.userId, this.content, this.channelId, this.timer,
-				this.trigger, this.occurences
-			);
-			if (this.timer < 2147483648) this.interval();
-		} else if (this.trigger === null && this.timer < 2147483648) {
+		this.remind = data.remind || Date.now();
+		if (this.trigger === null && this.timer < 2147483648) {
 			this.remind = data.remind === null ? this.remind : data.remind;
-			if (this.remind < Date.now()) {
+			if (this.remind < Date.now() && !first) {
 				this.send(true);
 				this.update(true);
-			} else this.timeout();
+			} else this.timeout(first ? this.timer : 0);
 		}
 	}
 
-	timeout() {
+	timeout(delay = 0) {
 		this.timerTimeout = setTimeout(() => {
 			this.occurences--;
 			this.send();
 			if (this.occurences === 0) this.delete();
 			this.update();
 			this.interval();
-		}, this.remind - Date.now());
+		}, this.remind + delay - Date.now());
 	}
 
 	interval() {
@@ -48,19 +37,30 @@ module.exports = class CustomTimer {
 		}, this.timer);
 	}
 
-	async create(userId, content, channelId, timer, trigger, occurences) {
-		if (trigger === null) {
-			const result = await this.client.database
-				.query(`INSERT INTO timers (userId, content, channelId, timer, occurences, remind) VALUES ("${userId}", "${content}", "${channelId}", ${timer}, ${occurences}, ${Date.now()})`);
-			this.id = result.insertId;
-			this.client.customTimers.set(this.id, this);
-			return result;
-		}
-		const result = this.client.database
-			.query(`INSERT INTO timers (userId, content, channelId, trigger, timer) VALUES ("${userId}", "${content}", "${channelId}", ${trigger}, "${timer}")`);
-		this.id = result.insertId;
-		this.client.customTimers.set(this.id, this);
-		return result;
+	static async create(client, data) {
+		return new Promise((resolve, reject) => {
+			const { userId, content, channelId, trigger, timer } = data;
+			const occurences = data.occurences || 10;
+			const remind = Date.now();
+			if (userId && content && timer && trigger === undefined) { // When the custom timer is interval-based
+				const query = channelId !== null
+					? `INSERT INTO timers (userId, content, channelId, timer, occurences, remind) VALUES ("${userId}", "${content}", "${channelId}", ${timer}, ${occurences}, ${remind})`
+					: `INSERT INTO timers (userId, content, timer, occurences, remind) VALUES ("${userId}", "${content}", ${timer}, ${occurences}, ${remind})`;
+				client.database.query(query).then(result => {
+					const id = result.insertId;
+					const customTimer = new CustomTimer(client,
+						{ ...data, remind, id }, true);
+					client.customTimers.set(id, customTimer); // Adds the custom timer to the registry
+					resolve(customTimer);
+				}).catch(reject);
+			/* } else if (userId && content && timer && trigger) { // When the custom timer is trigger-based
+				client.database.query(`INSERT INTO timers (userId, content, channelId, trigger, timer) VALUES ("${userId}", "${content}", "${channelId}", ${trigger}, "${timer}")`).then(result => {
+					const customTimer = new CustomTimer(client, data);
+					client.customTimers.set(result.insertId, customTimer);
+					resolve(customTimer);
+				}).catch(reject); */
+			} else reject(new TypeError("INVALID_DATA"));
+		});
 	}
 
 	async update(fixOffset = false) {
@@ -76,7 +76,11 @@ module.exports = class CustomTimer {
 		const user = await this.client.users.fetch(this.userId);
 		if (this.channelId === null) {
 			user.send(`Here is your reminder${this.content !== null ? ` for **${this.content}**` : ""}!${late ? "\n*This reminder is late due to the bot being down. Sorry for the inconvenience.*" : ""}`).catch(this.delete);
-		} else this.client.channels.cache.get(this.channelId).send(`<@${this.userId}>, here is your reminder${this.content !== null ? ` for **${this.content}**` : ""}!${late ? "\n*This reminder is late due to the bot being down. Sorry for the inconvenience.*" : ""}`).catch(this.delete);
+		} else if (this.client.channels.cache.get(this.channelId)) {
+			this.client.channels.cache.get(this.channelId)
+				.send(`<@${this.userId}>, here is your reminder${this.content !== null ? ` for **${this.content}**` : ""}!${late ? "\n*This reminder is late due to the bot being down. Sorry for the inconvenience.*" : ""}`)
+				.catch(this.delete);
+		}
 	}
 
 	async delete() {

--- a/src/structures/djs/TextChannel.js
+++ b/src/structures/djs/TextChannel.js
@@ -44,7 +44,7 @@ module.exports = BaseTextChannel => class TextChannel extends BaseTextChannel {
 			.setTitle(title)
 			.setColor("RED");
 		if (type === "UNEXPECTED_BEHAVIOR")
-			embed.setDescription(`${desc} Please contact the developers or fill a bug report with \`${this.guild.prefix}bugreport\`.`);
+			embed.setDescription(`${desc}\nPlease contact the developers or fill a bug report with \`${this.guild.prefix}bugreport\`.`);
 		else if (type === "INVALID_USER")
 			embed.setDescription("The user ID you have supplied is invalid, or the user you have mentionned does not exist. Make sure your user ID or your mention is correct.");
 		else embed.setDescription(desc);

--- a/src/structures/djs/TextChannel.js
+++ b/src/structures/djs/TextChannel.js
@@ -29,6 +29,7 @@ module.exports = BaseTextChannel => class TextChannel extends BaseTextChannel {
 			API_ERROR: () => "This API has thrown an error.",
 			API_RATELIMIT: () => "We have hit the ratelimit of (the endpoint of) this API.",
 			CUSTOM: res => res,
+			IMPOSSIBLE: () => "You are asking the impossible",
 			INCORRECT_CMD_USAGE: () => "This command has been used incorrectly.",
 			INVALID_USER: () => "The user specified does not exist.",
 			MISSING_ARGS: () => "Some arguments are missing.",


### PR DESCRIPTION
This pull request gets multiple changes to the bot. The changes are described below. You can see the fixes and similar changes in the commits list below.
 - **`REWORK`** **`#46`** `&customtimer` now benefits from a new documentation (which you can check out using `&?customtimer`, and it now works a bit differently in the code.
 - **`ADD`** **`#37`** `&help discordrpg` now works as an alias of `&help drpg`.
 - **`FIX`** **`#35`** `&skills` was not showing the right numbers for the mining skill XP gains.
 - **`FIX`** **`#39`** `&birb` no longer "makes bot go bye bye".
 - **`FIX`** **`#40`** `&plantcalc` was not erroring properly when a wrong seed name was supplied.
 - **`FIX`** **`#41`** `&emoji` was not working. It now also sends an error when there are too emojis to show.
 - **`FIX`** **`#42`** `&randimal` no longer crashes the bot.
 - **`FIX`** **`#43`** `&poke` was not working, even when used properly.
 - **`FIX`** **`#44`** `&curconv` was not working properly when invalid currencies were supplied.
 - **`FIX`** **`#45`** `&user` was not erroring properly when an invalid user ID was supplied.