### PR TITLE
Add timer ping configuration option & functionality

### DIFF
--- a/src/commands/settings/enabledrpg.js
+++ b/src/commands/settings/enabledrpg.js
@@ -4,10 +4,11 @@ const { Command } = require("../../groups/SettingsCommand");
 const descriptions = {
 	healthMonitor: "DiscordRPG Health Monitor",
 	adventureTimer: "DiscordRPG Adventure Timer",
-	sidesTimer: "DiscordRPG Sides Timer"
+	sidesTimer: "DiscordRPG Sides Timer",
+	timerPing: "DiscordRPG Timer Pings"
 };
 const guildParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
-const userParameters = ["healthMonitor", "adventureTimer", "sidesTimer"];
+const userParameters = ["healthMonitor", "adventureTimer", "sidesTimer", "timerPing"];
 
 module.exports = class EnableDRPGCommand extends Command {
 	constructor(client) {

--- a/src/utils/checks/configurationModels.js
+++ b/src/utils/checks/configurationModels.js
@@ -50,6 +50,17 @@ module.exports = {
 			showOnlyIfBotIsInGuild: "170915625722576896",
 			category: "DiscordRPG"
 		},
+		timerPing: {
+			support: value => (
+				value === "on"
+				|| value === "adventure"
+				|| value === "sides"
+				|| value === "off"
+			),
+			help: "Timer Pings - [on | adventure | sides | off]",
+			showOnlyIfBotIsInGuild: "170915625722576896",
+			category: "DiscordRPG"
+		},
 		timezone: {
 			support: timezoneSupport,
 			help:

--- a/src/utils/timer/DiscordRPG/adv.js
+++ b/src/utils/timer/DiscordRPG/adv.js
@@ -27,8 +27,12 @@ module.exports = message => {
 			: 0;
 		// eslint-disable-next-line no-param-reassign
 		message.author.timers.adventure = setTimeout(() => {
+			const ping = message.author.settings.timerPing === "adventure"
+				|| message.author.settings.timerPing === "on"
+				? `<@${message.author.id}>`
+				: `${message.author.username},`;
 			message.channel
-				.send(`<@${message.author.id}> adventure time! :crossed_swords:`)
+				.send(`${ping} adventure time! :crossed_swords:`)
 				.then(msg => {
 					if (message.guild.settings.autoDelete === "on") msg.delete({ timeout: 10000 });
 				});

--- a/src/utils/timer/DiscordRPG/sides.js
+++ b/src/utils/timer/DiscordRPG/sides.js
@@ -56,9 +56,13 @@ module.exports = async message => {
 									timerset.delete({ timeout: 5000 });
 									// eslint-disable-next-line no-param-reassign
 									message.author.timers.sides = setTimeout(() => {
+										const ping = message.author.settings.timerPing === "on"
+											|| message.author.settings.timerPing === "sides"
+											? `<@${message.author.id}>`
+											: `${message.author.username},`;
 										message.channel
 											.send(
-												`<@${message.author.id}> sides time! ${randomemoji}`
+												`${ping} sides time! ${randomemoji}`
 											)
 											.then(msg => {
 												if (message.guild.settings.autoDelete === "on") msg.delete({ timeout: 180000 });


### PR DESCRIPTION
This commit:

- adds the timer ping uconfig option (on | sides | adventure | off);
- changes the adventure timer to use an alternative output if the timer ping option is set
- changes the sides timer to use an alternative output if the timer ping option is set