### PR TITLE
showOnlyIfBotIsInGuild not working with cache

### DIFF
--- a/src/commands/settings/gconfig.js
+++ b/src/commands/settings/gconfig.js
@@ -12,7 +12,7 @@ module.exports = class GconfigCommand extends Command {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	run(bot, message, args) {
+	async run(bot, message, args) {
 		const parametersAvailable = bot.models.settings.guild;
 		if (args.length === 0) {
 			const { prefix } = message.guild;
@@ -26,9 +26,13 @@ module.exports = class GconfigCommand extends Command {
 		} else if (args.includes("list")) {
 			const list = {};
 			for (const [key, data] of Object.entries(parametersAvailable)) {
-				if (message.guild.members.cache.get(data.showOnlyIfBotIsInGuild)
-					|| data.showOnlyIfBotIsInGuild === undefined) {
-					if (list[data.category] === undefined) list[data.category] = {};
+				if (list[data.category] === undefined) list[data.category] = {};
+				if (data.showOnlyIfBotIsInGuild !== undefined) {
+					// eslint-disable-next-line no-await-in-loop
+					if (await message.guild.members.fetch(data.showOnlyIfBotIsInGuild)) {
+						list[data.category][key] = data;
+					}
+				} else {
 					list[data.category][key] = data;
 				}
 			}

--- a/src/commands/settings/uconfig.js
+++ b/src/commands/settings/uconfig.js
@@ -11,7 +11,7 @@ module.exports = class UconfigCommand extends Command {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	run(bot, message, args) {
+	async run(bot, message, args) {
 		const parametersAvailable = bot.models.settings.user;
 		if (args.length === 0) {
 			const { prefix } = message.guild;
@@ -28,9 +28,13 @@ module.exports = class UconfigCommand extends Command {
 		} else if (args.includes("list")) {
 			const list = {};
 			for (const [key, data] of Object.entries(parametersAvailable)) {
-				if (message.guild.members.cache.get(data.showOnlyIfBotIsInGuild)
-					|| data.showOnlyIfBotIsInGuild === undefined) {
-					if (list[data.category] === undefined) list[data.category] = {};
+				if (list[data.category] === undefined) list[data.category] = {};
+				if (data.showOnlyIfBotIsInGuild !== undefined) {
+					// eslint-disable-next-line no-await-in-loop
+					if (await message.guild.members.fetch(data.showOnlyIfBotIsInGuild)) {
+						list[data.category][key] = data;
+					}
+				} else {
 					list[data.category][key] = data;
 				}
 			}


### PR DESCRIPTION
Fixes an `&uconfig` and `&gconfig` issue where settings proper to a bot would not show up because the bot user was not in the discord.js cache.