### PR TITLE
Implemented timer ping for #!padv

### DIFF
--- a/src/utils/timer/DiscordRPG/padv.js
+++ b/src/utils/timer/DiscordRPG/padv.js
@@ -21,8 +21,12 @@ module.exports = message => {
 		if (message.guild.settings.autoDelete === "on")
 			message.delete({ timeout: 1000 });
 		message.author.timers.padventure = setTimeout(() => {
+			const ping = message.author.settings.timerPing === "adventure"
+                		|| message.author.settings.timerPing === "on"
+                		? `<@${message.author.id}>`
+                		: `${message.author.username},`;
 			message.channel
-				.send(`<@${message.author.id}> party adventure time! :crossed_swords:`)
+				.send(`${ping} party adventure time! :crossed_swords:`)
 				.then(msg => {
 					if (message.guild.settings.autoDelete === "on") msg.delete({ timeout: 10000 });
 				});


### PR DESCRIPTION
Pretty much copy-pasted the `timerPing` code from `adv.js` to `padv.js`.

I was also thinking, perhaps the `timerPing` should default to `on` (for users with no `settings.timerping` configuration)?