### PR TITLE
fix: mathjs breaking change

### DIFF
--- a/src/commands/drpg/plant.js
+++ b/src/commands/drpg/plant.js
@@ -50,10 +50,10 @@ module.exports = class PlantCommand extends Command {
 						const scope = { luck, passed, skillLevel };
 						const scopeMax = { luck: luckMax, passed, skillLevel };
 						const loots = item.sapling.loot.amount;
-						const normalMin = math.eval(loots.min, scope);
-						const normalMax = math.eval(loots.max, scope);
-						const highestMin = math.eval(loots.min, scopeMax);
-						const highestMax = math.eval(loots.max, scopeMax);
+						const normalMin = math.evaluate(loots.min, scope);
+						const normalMax = math.evaluate(loots.max, scope);
+						const highestMin = math.evaluate(loots.min, scopeMax);
+						const highestMax = math.evaluate(loots.max, scopeMax);
 						const rewardName = items[item.sapling.loot.id[0]].name;
 						const normalRewards = normalMin === normalMax
 							? `**${normalMin} ${rewardName}**`

--- a/src/commands/drpg/plantcalc.js
+++ b/src/commands/drpg/plantcalc.js
@@ -22,8 +22,8 @@ module.exports = class PlantcalcCommand extends Command {
 				if (element.name.toLowerCase() === itemName) item = element;
 			if (item.sapling) {
 				const scope = { luck: points, passed: hours * 3600 };
-				const min = math.eval(item.sapling.loot.amount.min, scope);
-				const max = math.eval(item.sapling.loot.amount.max, scope);
+				const min = math.evaluate(item.sapling.loot.amount.min, scope);
+				const max = math.evaluate(item.sapling.loot.amount.max, scope);
 				message.channel.send(`Estimated ${min} - ${max} when planted for ${hours} hours. `);
 			} else message.channel.error("WRONG_USAGE", "You need to provide the name of a valid sapling.");
 		} else message.channel.send("You must provide reaping points, hours set and item name. Example (&plantcalc 1 24 olive)");

--- a/src/commands/drpg/trap.js
+++ b/src/commands/drpg/trap.js
@@ -54,8 +54,8 @@ module.exports = class TrapCommand extends Command {
 						const pronoun = message.author.id === userid ? "You" : "They";
 						let items = "";
 						itemList[trap.id].trap.loot.forEach(item => {
-							const min = math.eval(item.amount.min, scope);
-							const max = math.eval(item.amount.max, scope);
+							const min = math.evaluate(item.amount.min, scope);
+							const max = math.evaluate(item.amount.max, scope);
 							const itemName = itemList[item.id].name;
 							if (elapsedTime > item.mintime) {
 								if (min === max)

--- a/src/commands/utilities/math.js
+++ b/src/commands/utilities/math.js
@@ -19,7 +19,7 @@ module.exports = class MathCommand extends Command {
 			try {
 				result = args.join(" ") === "10 + 9" || args.join(" ") === "10+9"
 					? 21
-					: mathjs.eval(args.join(" ").replace(/,/g, ""));
+					: mathjs.evaluate(args.join(" ").replace(/,/g, ""));
 			} catch (err) {
 				result = "The specified math expression is invalid.";
 			}


### PR DESCRIPTION
Fixes a bug caused by a `mathjs` package breaking change which renamed the `eval` method to `evaluate`.