### PR TITLE
Add command links to timer messages

### DIFF
--- a/src/utils/timer/DiscordRPG/adv.ts
+++ b/src/utils/timer/DiscordRPG/adv.ts
@@ -37,7 +37,7 @@ export default async (ctx: MessageContext) => {
 				|| user.settings.timerping === "on"
 				? `<@${ctx.message.author.id}>`
 				: `${ctx.message.author.username},`;
-			ctx.reply(`${ping} adventure time! :crossed_swords:`).then(msg => {
+			ctx.reply(`${ping} adventure time! :crossed_swords: </adv:1010513953815806044>`).then(msg => {
 				if (guild.settings.autodelete === "on") {
 					setTimeout(() => msg.delete(), 10000);
 				}

--- a/src/utils/timer/DiscordRPG/padv.ts
+++ b/src/utils/timer/DiscordRPG/padv.ts
@@ -32,7 +32,7 @@ export default async (ctx: MessageContext) => {
 				|| user.settings.timerping === "on"
 				? `<@${ctx.message.author.id}>`
 				: `${ctx.message.author.username},`;
-			ctx.reply(`${ping} party adventure time! :crossed_swords:`).then(msg => {
+			ctx.reply(`${ping} party adventure time! :crossed_swords: </padv:1010513953903874069>`).then(msg => {
 				if (guild.settings.autodelete === "on") {
 					setTimeout(() => msg.delete(), 10000);
 				}

--- a/src/utils/timer/DiscordRPG/sides.ts
+++ b/src/utils/timer/DiscordRPG/sides.ts
@@ -65,7 +65,7 @@ export default async (ctx: MessageContext) => {
 										|| user.settings.timerping === "sides"
 										? `<@${user.id}>`
 										: `${user.username},`;
-									ctx.reply(`${ping} sides time! ${randomemoji}`).then(msg => {
+									ctx.reply(`${ping} sides time! ${randomemoji} </mine:1010513953903874076> </chop:1010513953903874072> </forage:1010513953903874075> </fish:1010513953903874074>`).then(msg => {
 										if (guild.settings.autodelete === "on") {
 											setTimeout(() => msg.delete(), 180000);
 										}


### PR DESCRIPTION
Links the commands to timer pings so users can just click them to insert them into the chat box.
![image](https://user-images.githubusercontent.com/24826881/187834068-2336acca-5393-4132-a69a-feef9abf9c60.png)
